### PR TITLE
Remove the "see also" in Readme and remove "is_opensuse" in spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,3 @@ More details about SAP WMP in general is in
   * Commit everything into git (changelog is generated from it), then run `iosc
     service disabledrun` locally and commit into your IBS package.
   * When preparing a MU, submit from your package into the respective target.
-
-## See also
-
-This is based on modifying SAP profile. For the rejected and unmaintained
-variant see the branch
-
-  * [PAM based](https://gitlab.suse.de/mkoutny/wmp-repo/tree/pam-rpm) (non-public).
-

--- a/rpm/sapwmp.spec
+++ b/rpm/sapwmp.spec
@@ -23,13 +23,13 @@ Release:        0
 Summary:        Configuration and utilities for collecting SAP processes under control group
 License:        GPL-2.0-only
 Group:          Productivity/Databases/Servers
-%if 0%{?sle_version} == 150000 && !0%{?is_opensuse}
+%if 0%{?sle_version} == 150000
 URL:            https://documentation.suse.com/sles-sap/15-GA/html/SLES4SAP-guide/cha-s4s-tune.html#sec-s4s-memory-protection
 %endif
-%if 0%{?sle_version} == 150100 && !0%{?is_opensuse}
+%if 0%{?sle_version} == 150100
 URL:            https://documentation.suse.com/sles-sap/15-SP1/html/SLES4SAP-guide/cha-s4s-tune.html#sec-s4s-memory-protection
 %endif
-%if 0%{?sle_version} >= 150200 && !0%{?is_opensuse}
+%if 0%{?sle_version} >= 150200
 URL:            https://documentation.suse.com/sles-sap/15-SP2/html/SLES-SAP-guide/cha-tune.html#sec-memory-protection
 %endif
 Source0:        %{name}-%{version}.tar.xz
@@ -47,7 +47,7 @@ Requires(post): %fillup_prereq
 Requires(post): permissions
 Requires:       util-linux-systemd
 # We need kernel fix for bsc#1174002
-%if 0%{?sle_version} == 150200 && !0%{?is_opensuse}
+%if 0%{?sle_version} == 150200
 Requires:       kernel >= 5.3.18-24.12
 %endif
 %{?systemd_requires}


### PR DESCRIPTION
1. The see also refered an outdate internal gitlab branch
2. Remove the is_opensuse marco is possible.
    Due to the policy of closing the leap gap, not to use is_opensuse marco unless have to.    
    opensuse can also refer to sle doc, leap15.2 include "kernel >= 5.3.18-24.12" already
