### PR TITLE
Add wmp checker and remove the duplicated source in spec file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ More details about SAP WMP in general is in
   * Commit everything into git (changelog is generated from it), then run `iosc
     service disabledrun` locally and commit into your IBS package.
   * When preparing a MU, submit from your package into the respective target.
+
+
+## Tools
+
+  * [wmp-check.sh](./scripts/wmp-check.sh)
+```
+# A script checks the setup of Workload Memory Protection.
+$ wmp-check.sh
+```

--- a/rpm/sapwmp.spec
+++ b/rpm/sapwmp.spec
@@ -70,12 +70,14 @@ install -D -m 644 %{wmpd}/rpm/sapwmp.conf %{buildroot}/%{_sysconfdir}/sapwmp.con
 install -D -m 644 %{wmpd}/rpm/SAP.slice %{buildroot}/%{_unitdir}/SAP.slice
 install -D -m 755 %{wmpd}/rpm/supportconfig-sapwmp %{buildroot}%{_prefix}/lib/supportconfig/plugins/sapwmp
 install -D -m 744 %{wmpd}/rpm/wmp-sample-memory.sh %{buildroot}/%{_libexecdir}/sapwmp/wmp-sample-memory
-install -D -m 744 %{wmpd}/rpm/wmp-sample-memory.service %{buildroot}/%{_unitdir}/wmp-sample-memory.service
-install -D -m 744 %{wmpd}/rpm/wmp-sample-memory.timer %{buildroot}/%{_unitdir}/wmp-sample-memory.timer
+install -D -m 644 %{wmpd}/rpm/wmp-sample-memory.service %{buildroot}/%{_unitdir}/wmp-sample-memory.service
+install -D -m 644 %{wmpd}/rpm/wmp-sample-memory.timer %{buildroot}/%{_unitdir}/wmp-sample-memory.timer
 
 mkdir -p %{buildroot}/%{_libexecdir}/sapwmp/scripts
 install -D -m 755 %{wmpd}/scripts/*.sh %{buildroot}/%{_libexecdir}/sapwmp/scripts/
-install -D -m 644 %{wmpd}/scripts/README* %{buildroot}/%{_libexecdir}/sapwmp/scripts/
+
+mkdir -p %{buildroot}/%{_defaultdocdir}/sapwmp
+install -D -m 644 %{wmpd}/scripts/README* %{buildroot}/%{_defaultdocdir}/sapwmp
 
 %verifyscript
 %verify_permissions -e %{_libexecdir}/sapwmp/sapwmp-capture
@@ -127,5 +129,6 @@ fi
 %dir %{_prefix}/lib/supportconfig/plugins
 %{_prefix}/lib/supportconfig/plugins/sapwmp
 %{_libexecdir}/sapwmp/scripts
+%{_defaultdocdir}/sapwmp
 
 %changelog

--- a/rpm/sapwmp.spec
+++ b/rpm/sapwmp.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package sapwmp
 #
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2021 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -73,8 +73,8 @@ install -D -m 744 %{wmpd}/rpm/wmp-sample-memory.sh %{buildroot}/%{_libexecdir}/s
 install -D -m 644 %{wmpd}/rpm/wmp-sample-memory.service %{buildroot}/%{_unitdir}/wmp-sample-memory.service
 install -D -m 644 %{wmpd}/rpm/wmp-sample-memory.timer %{buildroot}/%{_unitdir}/wmp-sample-memory.timer
 
-mkdir -p %{buildroot}/%{_libexecdir}/sapwmp/scripts
-install -D -m 755 %{wmpd}/scripts/*.sh %{buildroot}/%{_libexecdir}/sapwmp/scripts/
+mkdir -p %{buildroot}%{_sbindir}
+install -D -m 755 %{wmpd}/scripts/wmp-check.sh %{buildroot}%{_sbindir}/wmp-check
 
 mkdir -p %{buildroot}/%{_defaultdocdir}/sapwmp
 install -D -m 644 %{wmpd}/scripts/README* %{buildroot}/%{_defaultdocdir}/sapwmp
@@ -101,9 +101,9 @@ EOD
 # set with systemctl set-property and reassign to the current 'SAP.slice' (keep
 # runtime copy for 'sap.slice').
 # systemctl-daemon reload is implicit in the following service_add_post.
-if [ "$1" -eq "2" -a -d /etc/systemd/system.control/sap.slice.d ] ; then
-	cp -r /etc/systemd/system.control/sap.slice.d /run/systemd/system.control/sap.slice.d || :
-	mv /etc/systemd/system.control/sap.slice.d /etc/systemd/system.control/SAP.slice.d \
+if [ "$1" -eq "2" -a -d %{_sysconfdir}/systemd/system.control/sap.slice.d ] ; then
+	cp -r %{_sysconfdir}/systemd/system.control/sap.slice.d /run/systemd/system.control/sap.slice.d || :
+	mv %{_sysconfdir}/systemd/system.control/sap.slice.d %{_sysconfdir}/systemd/system.control/SAP.slice.d \
 	 && echo "Migrated configuration from sap.slice to SAP.slice"
 fi
 %service_add_post wmp-sample-memory.service wmp-sample-memory.timer
@@ -118,6 +118,7 @@ fi
 %service_del_postun wmp-sample-memory.service wmp-sample-memory.timer
 
 %files
+%defattr(-, root, root)
 %dir %{_libexecdir}/sapwmp
 %verify(not user group mode) %attr(4750,root,%{group_sapsys}) %{_libexecdir}/sapwmp/sapwmp-capture
 %{_libexecdir}/sapwmp/wmp-sample-memory
@@ -128,7 +129,7 @@ fi
 %dir %{_prefix}/lib/supportconfig
 %dir %{_prefix}/lib/supportconfig/plugins
 %{_prefix}/lib/supportconfig/plugins/sapwmp
-%{_libexecdir}/sapwmp/scripts
+%{_sbindir}/wmp-check
 %{_defaultdocdir}/sapwmp
 
 %changelog

--- a/rpm/sapwmp.spec
+++ b/rpm/sapwmp.spec
@@ -33,12 +33,6 @@ URL:            https://documentation.suse.com/sles-sap/15-SP1/html/SLES4SAP-gui
 URL:            https://documentation.suse.com/sles-sap/15-SP2/html/SLES-SAP-guide/cha-tune.html#sec-memory-protection
 %endif
 Source0:        %{name}-%{version}.tar.xz
-Source1:        sapwmp.conf
-Source2:        SAP.slice
-Source3:        supportconfig-sapwmp
-Source4:        wmp-sample-memory.sh
-Source5:        wmp-sample-memory.service
-Source6:        wmp-sample-memory.timer
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  systemd-devel
@@ -71,12 +65,17 @@ Configuration and utilities for collecting SAP processes under control group to 
 
 %install
 %make_install
-install -D -m 644 %{SOURCE1} %{buildroot}/%{_sysconfdir}/sapwmp.conf
-install -D -m 644 %{SOURCE2} %{buildroot}/%{_unitdir}/SAP.slice
-install -D -m 755 %{SOURCE3} %{buildroot}%{_prefix}/lib/supportconfig/plugins/sapwmp
-install -D -m 744 %{SOURCE4} %{buildroot}/%{_libexecdir}/sapwmp/wmp-sample-memory
-install -D -m 644 %{SOURCE5} %{buildroot}/%{_unitdir}/wmp-sample-memory.service
-install -D -m 644 %{SOURCE6} %{buildroot}/%{_unitdir}/wmp-sample-memory.timer
+%define wmpd %{_builddir}/%{name}-%{version}
+install -D -m 644 %{wmpd}/rpm/sapwmp.conf %{buildroot}/%{_sysconfdir}/sapwmp.conf
+install -D -m 644 %{wmpd}/rpm/SAP.slice %{buildroot}/%{_unitdir}/SAP.slice
+install -D -m 755 %{wmpd}/rpm/supportconfig-sapwmp %{buildroot}%{_prefix}/lib/supportconfig/plugins/sapwmp
+install -D -m 744 %{wmpd}/rpm/wmp-sample-memory.sh %{buildroot}/%{_libexecdir}/sapwmp/wmp-sample-memory
+install -D -m 744 %{wmpd}/rpm/wmp-sample-memory.service %{buildroot}/%{_unitdir}/wmp-sample-memory.service
+install -D -m 744 %{wmpd}/rpm/wmp-sample-memory.timer %{buildroot}/%{_unitdir}/wmp-sample-memory.timer
+
+mkdir -p %{buildroot}/%{_libexecdir}/sapwmp/scripts
+install -D -m 755 %{wmpd}/scripts/*.sh %{buildroot}/%{_libexecdir}/sapwmp/scripts/
+install -D -m 644 %{wmpd}/scripts/README* %{buildroot}/%{_libexecdir}/sapwmp/scripts/
 
 %verifyscript
 %verify_permissions -e %{_libexecdir}/sapwmp/sapwmp-capture
@@ -127,5 +126,6 @@ fi
 %dir %{_prefix}/lib/supportconfig
 %dir %{_prefix}/lib/supportconfig/plugins
 %{_prefix}/lib/supportconfig/plugins/sapwmp
+%{_libexecdir}/sapwmp/scripts
 
 %changelog

--- a/scripts/README-wmp-check.md
+++ b/scripts/README-wmp-check.md
@@ -1,0 +1,165 @@
+# [wmp-check.sh](./wmp-check.sh)
+> This script originally developed in repo https://github.com/scmschmidt/wmp_check.git
+> Merged into this repo at v1.1.1
+
+This script checks the setup of Workload Memory Protection.
+
+- Correct setup of cgroup2
+- Checc the required rpm packages version
+- Ownership and permission of the capture program
+- WMP entries of SAP instance profiles
+- Correct cgroup of running SAP instance processes.
+- Correct setup of SAP.slice
+- Sane configuration of MemoryLow (It can not determine, if the MemoryLow value has been chosen wisely!)
+- Setup of the optional memory sampler
+- Setup of optional swap accounting
+
+Please keep in mind:
+
+ - It does not check if you have the latest version installed, only minimum version.
+ - It assumes SAP instances profiles can be found beneath /usr/sap/<SID>/SYS/profile/.
+ - This tool does not check, if the memory.low value is set correctly.
+
+
+## Usage
+```
+wmp-check.sh
+```
+
+## Examples
+
+WMP has been setup correctly for all three existent SAP instances:
+
+```
+# ./wmp-check.sh
+
+This is wmp_check v0.1.
+It verifies if WMP is set up correctly.
+
+Please keep in mind:
+ - It does not check if you have the latest version installed.
+ - It assumes SAP instances profiles can be found beneath /usr/sap/<SID>/SYS/profile/.
+ - This tool does not check, if the memory.low value is set correctly.
+
+[ OK ]  cgroup2 unified hierarchy is mounted to /sys/fs/cgroup and configured in /etc/default/grub.
+[ OK ]  capture program has correct ownership and permissions.
+[NOTE]  WMP entry for the WMP capture program found for instance HA0_ASCS00_sapha0as.
+[NOTE]  WMP entry for the WMP capture program found for instance HA0_D01_sapha0ci.
+[NOTE]  WMP entry for the WMP capture program found for instance HA0_ERS10_sapha0er.
+[ OK ]  All SAP instances contain the entry for the WMP capture program.
+[ OK ]  SAP slice is active.
+[ OK ]  MemoryLow is set and in use.
+[NOTE]  All processes of HA0_ASCS00_sapha0as are in SAP.slice.
+[NOTE]  All processes of HA0_D01_sapha0ci are in SAP.slice.
+[NOTE]  All processes of HA0_ERS10_sapha0er are in SAP.slice.
+[ OK ]  All SAP instance processes are inside SAP.slice.
+[ OK ]  MemoryLow is not larger then the current allocated memory for SAP.slice.
+[ OK ]  MemoryLow of SAP.slice is less then total memory.
+[NOTE]  The timer unit wmp-sample-memory.timer to collect monitor data is active.
+[NOTE]  The optional timer unit wmp-sample-memory.timer to collect monitor data is enabled.
+[NOTE]  Optional swap accounting is active and can be monitored.
+[NOTE]  Optional swap accounting is configured in /etc/default/grub.
+
+WMP is set up correctly.
+```
+
+Changing the instance profiles have been forgotten and the SAP instances are not running:
+
+```
+# ./wmp-check.sh
+
+This is wmp_check v0.1.
+It verifies if WMP is set up correctly.
+
+Please keep in mind:
+ - It does not check if you have the latest version installed.
+ - It assumes SAP instances profiles can be found beneath /usr/sap/<SID>/SYS/profile/.
+ - This tool does not check, if the memory.low value is set correctly.
+
+[ OK ]  cgroup2 unified hierarchy is mounted to /sys/fs/cgroup and configured in /etc/default/grub.
+[ OK ]  capture program has correct ownership and permissions.
+[NOTE]  No entry for the WMP capture program found in /usr/sap/HA0/SYS/profile/HA0_ASCS00_sapha0as.
+[NOTE]  No entry for the WMP capture program found in /usr/sap/HA0/SYS/profile/HA0_D01_sapha0ci.
+[NOTE]  No entry for the WMP capture program found in /usr/sap/HA0/SYS/profile/HA0_ERS10_sapha0er.
+[FAIL]  All SAP instances miss the entry for the WMP capture program!
+        -> Add the entry to the instance profile of the chosen instances.
+[ OK ]  SAP slice is active.
+[ OK ]  MemoryLow is set and in use.
+[NOTE]  Instance HA0_ASCS00_sapha0as has processes outside SAP.slice: 24697 24753 24751 24079.
+[NOTE]  Instance HA0_D01_sapha0ci has processes outside SAP.slice: 24730 25159 25211 25212 25214 25215 25216 25217 25218 25219 25229 25228 25221 25220 25223 25222 25225 25224 25227 25226 25234 25232 25233 25230 25231.
+[NOTE]  Instance HA0_ERS10_sapha0er has processes outside SAP.slice: 24306 24935 24947.
+[FAIL]  All SAP instances are outside SAP.slice!
+        -> Check your configuration and restart the instance.
+[ OK ]  MemoryLow is not larger then the current allocated memory for SAP.slice.
+[ OK ]  MemoryLow of SAP.slice is less then total memory.
+
+2 error(s) have been found.
+WMP will not work properly!
+```
+
+WMP has been setup correctly for all three existent SAP instances, but there is a warning about 
+MemoryLow which *might* be to high and leaves to less memory for the rest of the system:
+
+```
+# ./wmp-check.sh
+
+This is wmp_check v0.1.
+It verifies if WMP is set up correctly.
+
+Please keep in mind:
+ - It does not check if you have the latest version installed.
+ - It assumes SAP instances profiles can be found beneath /usr/sap/<SID>/SYS/profile/.
+ - This tool does not check, if the memory.low value is set correctly.
+
+[ OK ]  cgroup2 unified hierarchy is mounted to /sys/fs/cgroup and configured in /etc/default/grub.
+[ OK ]  capture program has correct ownership and permissions.
+[NOTE]  WMP entry for the WMP capture program found for instance HA0_ASCS00_sapha0as.
+[NOTE]  WMP entry for the WMP capture program found for instance HA0_D01_sapha0ci.
+[NOTE]  WMP entry for the WMP capture program found for instance HA0_ERS10_sapha0er.
+[ OK ]  All SAP instances contain the entry for the WMP capture program.
+[ OK ]  SAP slice is active.
+[ OK ]  MemoryLow is set and in use.
+[NOTE]  All processes of HA0_ASCS00_sapha0as are in SAP.slice.
+[NOTE]  All processes of HA0_D01_sapha0ci are in SAP.slice.
+[NOTE]  All processes of HA0_ERS10_sapha0er are in SAP.slice.
+[ OK ]  All SAP instance processes are inside SAP.slice.
+[ OK ]  MemoryLow is not larger then the current allocated memory for SAP.slice.
+[WARN]  MemoryLow of SAP.slice (15498389487) is very close to the total physical memory (15977289039)!
+[NOTE]  The timer unit wmp-sample-memory.timer to collect monitor data is active.
+[NOTE]  The optional timer unit wmp-sample-memory.timer to collect monitor data is enabled.
+[NOTE]  Optional swap accounting is active and can be monitored.
+[NOTE]  Optional swap accounting is configured in /etc/default/grub.
+
+WMP is set up correctly.
+```
+
+
+## Exit Codes
+| exit code | description                                                        |
+|-----------|--------------------------------------------------------------------|
+|     0     | All checks ok. WMP has been set up correctly.                      |
+|     1     | Some warnings occured. WMP should work, but better check manually. |
+|     2     | Some errors occured. WMP will not work.                            |
+|     3     | Wrong parameters given to the tool on commandline.                 |
+
+
+## Changelog
+
+|    date    | version  | comment                                               |
+|------------|----------|-------------------------------------------------------|
+| 12.10.2020 | v1.0     | First release                                         |
+| 13.10.2020 | v1.0.1   | Added check of memory.low=max for SAP.slice children  |
+| 03.11.2020 | v1.0.2   | Fixed wrong permissions in capture program test       |
+|            |          | Fixed OS version detection                            |
+|            |          | Fixed issues with MemoryLow test                      |
+|            |          | Fixed issues with profile detection                   |
+|            |          | Fixed issue with cgroup detection                     |
+|            |          | Added cgroup v1 detection                             |
+| 09.12.2020 | v1.0.3   | Optimized pattern for profile detection               |
+| 14.12.2020 | v1.1.0   | cgroup2 mount detection fixed                         |
+|            |          | Further optimized pattern for profile detection       |
+|            |          | Detection of SAP instances reworked a bit             |
+| 09.04.2021 | v1.1.1   | Add colorful output                                   |
+|            |          | Check generated grub2 configure                       |
+|            |          | Enable support for SLE15SP0/SP1                       |
+|            |          | Support RPM package version check                     |

--- a/scripts/README-wmp-check.md
+++ b/scripts/README-wmp-check.md
@@ -23,7 +23,7 @@ Please keep in mind:
 
 ## Usage
 ```
-wmp-check.sh
+/usr/lib/sapwmp/scripts/wmp-check.sh
 ```
 
 ## Examples
@@ -31,7 +31,7 @@ wmp-check.sh
 WMP has been setup correctly for all three existent SAP instances:
 
 ```
-# ./wmp-check.sh
+# /usr/lib/sapwmp/scripts/wmp-check.sh
 
 This is wmp_check v0.1.
 It verifies if WMP is set up correctly.
@@ -66,7 +66,7 @@ WMP is set up correctly.
 Changing the instance profiles have been forgotten and the SAP instances are not running:
 
 ```
-# ./wmp-check.sh
+# /usr/lib/sapwmp/scripts/wmp-check.sh
 
 This is wmp_check v0.1.
 It verifies if WMP is set up correctly.
@@ -101,7 +101,7 @@ WMP has been setup correctly for all three existent SAP instances, but there is 
 MemoryLow which *might* be to high and leaves to less memory for the rest of the system:
 
 ```
-# ./wmp-check.sh
+# /usr/lib/sapwmp/scripts/wmp-check.sh
 
 This is wmp_check v0.1.
 It verifies if WMP is set up correctly.

--- a/scripts/README-wmp-check.md
+++ b/scripts/README-wmp-check.md
@@ -23,7 +23,7 @@ Please keep in mind:
 
 ## Usage
 ```
-/usr/lib/sapwmp/scripts/wmp-check.sh
+wmp-check
 ```
 
 ## Examples
@@ -31,7 +31,7 @@ Please keep in mind:
 WMP has been setup correctly for all three existent SAP instances:
 
 ```
-# /usr/lib/sapwmp/scripts/wmp-check.sh
+# wmp-check
 
 This is wmp_check v0.1.
 It verifies if WMP is set up correctly.
@@ -66,7 +66,7 @@ WMP is set up correctly.
 Changing the instance profiles have been forgotten and the SAP instances are not running:
 
 ```
-# /usr/lib/sapwmp/scripts/wmp-check.sh
+# wmp-check
 
 This is wmp_check v0.1.
 It verifies if WMP is set up correctly.
@@ -101,7 +101,7 @@ WMP has been setup correctly for all three existent SAP instances, but there is 
 MemoryLow which *might* be to high and leaves to less memory for the rest of the system:
 
 ```
-# /usr/lib/sapwmp/scripts/wmp-check.sh
+# wmp-check
 
 This is wmp_check v0.1.
 It verifies if WMP is set up correctly.

--- a/scripts/wmp-check.sh
+++ b/scripts/wmp-check.sh
@@ -1,0 +1,820 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# Copyright (c) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 3 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE Linux GmbH.
+#
+# ------------------------------------------------------------------------------
+# Author: Sören Schmidt <soeren.schmidt@suse.com>
+#
+# This tool checks if WMP is set up correctly. 
+#
+# exit codes:       0   All checks ok. WMP has been set up correctly.
+#                   1   Some warnings occured. WMP should work, but better check manually.
+#                   2   Some errors occured. WMP will not work.
+#                   3   Wrong parameters given to the tool on commandline.
+#
+# Changelog:
+#
+# 12.10.2020  v1.0      First release
+# 13.10.2020  v1.0.1    Added check of memory.low=max for SAP.slice children
+# 03.11.2020  v1.0.2    Fixed wrong permissions in capture program test
+#                       Fixed OS version detection 
+#                       Fixed issues with MemoryLow test
+#                       Fixed issues with profile detection
+#                       Fixed issue with cgroup detection  
+#                       Added cgroup v1 detection
+# 09.12.2020  v1.0.3    Optimized pattern for profile detection
+# 14.12.2020  v1.1.0    cgroup2 mount detection fixed
+#                       Further optimized pattern for profile detection  
+#                       Detection of SAP instances reworked a bit
+# 09.04.2021  v1.1.1    Add colorful output
+#                       Check generated grub2 configure
+#                       Enable support for SLE15SP0/SP1
+#                       Support RPM package version check
+
+version="1.1.1"
+
+# We use these global arrays through out the program:
+#
+# package_version                -  contains package version (string)
+# cgroup_unified                 -  contains if unified cgroup hierarchy is configured and active
+# capture_state                  -  contains permission and ownership of the capturer program
+# SAP_profile_path               -  contains profile path of SAP instances 
+# SAP_profile_wmp_entry          -  contains WMP entry in SAP profiles
+# memory_info                    -  contains system memory information 
+# SAP_slice_data                 -  contains information about SAP.slice
+# SAP_instance_processes         -  contains pids of that instance
+# SAP_processes_outside_cgroup   -  contains pids of that instance which are not in SAP.slice
+# SAP_sapstartsrv_outside_cgroup -  contains flag per instance if only sapstartsrv processes are outside the cgroup
+# unit_state_active              -  contains systemd unit state (systemctl is-active) 
+# unit_state_enabled             -  contains systemd unit state (systemctl is-enabled) 
+# swapaccounting_state           -  contains if cgroup swap accounting is configured and active
+declare -A package_version required_pkgs cgroup_unified capture_state memory_info SAP_profile_path SAP_profile_wmp_entry SAP_slice_data SAP_instance_processes SAP_processes_outside_cgroup SAP_sapstartsrv_outside_cgroup unit_state_active unit_state_enabled swapaccounting_state
+
+# Required packages list
+# examples:
+#		[{name}]="{version}-{release}"
+#		[{name}]="{version}"
+#		[{name}]=""
+required_pkgs=(
+    [sapwmp]=""
+    [systemd]="234-24.67.1"
+)
+
+# Some counters.
+SAP_processes=0
+SAP_processes_outside=0
+
+# Colorful output, set to 'false' to disable.
+# Disable color automatically if we run in a pipe
+ENABLE_COLORIZE=true
+[ -t 1 ] || ENABLE_COLORIZE=false
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+GRAY='\033[0;37m'
+RESET='\033[0m'
+
+if [[ $ENABLE_COLORIZE = false ]];then
+    unset RED GREEN YELLOW GRAY RESET
+fi
+
+function header() { 
+    local len=${#1}
+    echo -e "\n${1}"
+    printf '=%.s' $(eval "echo {1.."$((${len}))"}")
+    echo
+}
+
+function print_ok() {
+    local text="  ${@}"
+    echo -e "[ ${GREEN}OK${RESET} ]${text}"
+}
+
+function print_fail() {
+    local text="${1}"
+    local hint="${2}"
+    echo -e "[${RED}FAIL${RESET}]  ${text}\n        -> ${hint}"
+}
+
+function print_warn() {
+    local text="  ${@}"
+    echo -e "[${YELLOW}WARN${RESET}]${text}"
+}
+
+function print_note() {
+    local text="  ${@}"
+    echo -e "[${GRAY}NOTE${RESET}]${text}"
+}
+
+function version_lt() {
+    # Params:   VERSION1 VERSION2
+    # Output:   -
+    # Exitcode: boolean result
+    #
+    # Compare the two RPM package version
+	#
+    # Requires: -
+    test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" != "$1";
+}
+
+function get_package_versions() {
+    # Params:   PACKAGE...
+    # Output:   -
+    # Exitcode: -
+    #
+    # Determines package version as string for each PACKAGE.
+    # Not installed packages will have an empty string as version.
+    #
+    # The function updates the associative array "package_version".
+    #
+    # Requires:-
+
+    local package version release
+    for package in "${@}" ; do
+        if version=$(rpm -q --qf '%{version}' "${package}" 2>&1) ; then
+            if release=$(rpm -q --qf '%{release}' "${package}" 2>&1) ; then
+                package_version["${package}"]=${version}-${release}
+            else
+                package_version["${package}"]=${version}
+            fi
+        else
+            package_version["${package}"]=''
+        fi
+    done
+}
+
+function get_cgroup_state() {
+    # Params:   -
+    # Output:   -
+    # Exitcode: -
+    #
+    # Determines if cgroup2 unified hierarchy is configured and active.
+    # It also checks for remaining cgroup v1 controllers.
+    #
+    # The function updates the associative array "cgroup_unified".
+    #
+    # Requires: -
+
+    if [[ $(grep 'GRUB_CMDLINE_LINUX_DEFAULT' /etc/default/grub) =~ systemd.unified_cgroup_hierarchy=(1|true|yes) ]] ; then
+        if [[ $(grep '[[:space:]]linux[[:space:]]' /boot/grub2/grub.cfg) =~ systemd.unified_cgroup_hierarchy=(1|true|yes) ]] ; then
+            cgroup_unified['configured']='yes'
+        else
+            cgroup_unified['configured']='needupdate'
+        fi
+    else
+        cgroup_unified['configured']='no'
+    fi
+    if egrep -q '^cgroup.? /sys/fs/cgroup cgroup2' /proc/mounts ; then
+        cgroup_unified['active']='yes'
+    else
+        cgroup_unified['active']='no'
+    fi
+    if cut -d ' ' -f 3 /proc/mounts | grep -q '^cgroup$' ; then
+        cgroup_unified['v1-controllers']=$(grep ' cgroup ' /proc/mounts | cut -d ' ' -f 4 | tr ',' '\n' | sort -u | egrep '^(cpu|cpuacct|cpuset|memory|devices|freezer|net_cls|blkio|perf_event|net_prio|hugetlb|pids|rdma)$' | tr '\n' ' ')  # not very beautiful...
+    else
+        cgroup_unified['v1-controllers']='no'
+    fi
+}
+
+function get_capture_state() {
+    # Params:   -
+    # Output:   -
+    # Exitcode: -
+    #
+    # Determines ownership and permissions of the capture program.
+    #
+    # The function updates the associative array "capture_state".
+    #
+    # Requires: -
+
+    capture_state['name']='/usr/lib/sapwmp/sapwmp-capture'
+
+    if [ -e "${capture_state['name']}" ] ; then
+        capture_state['exists']='yes'
+        read capture_state['permissions'] capture_state['ownership'] < <(stat -c '%a %U:%G' "${capture_state['name']}" 2> /dev/null) 
+    else
+        capture_state['exists']='no'
+    fi
+}
+
+function get_SAP_profile_data() {
+    # Params:   -
+    # Output:   -
+    # Exitcode: -
+    #
+    # Collcets data of SAP instance profiles.
+    #
+    # The function updates the associative arrays "SAP_profile_path" and "SAP_profile_wmp_entry".
+    #
+    # Requires: capture_state['name'] set by get_capture_state()
+
+    local capture_pattern path profile 
+
+    capture_pattern="^[[:space:]]*Execute_[[:digit:]]+[[:space:]]*=[[:space:]]*local[[:space:]]+${capture_state['name']}"
+
+    for path in /usr/sap/*/SYS/profile/* ; do 
+        [[ "${path}" =~ /[[:alnum:]]+_[[:alnum:]]+_[[:alnum:]-]+$ ]] || continue
+        profile="${path##*/}"
+        SAP_profile_path["${profile}"]="${path}"
+        SAP_profile_wmp_entry["${profile}"]=$(egrep "${capture_pattern}" "${path}")
+        SAP_profile_wmp_entry["${profile}"]="${SAP_profile_wmp_entry[${profile}]:=-}"
+    done
+}
+
+function get_system_meminfo() {
+    # Params:   -
+    # Output:   -
+    # Exitcode: -
+    #
+    # Collects memory infromation from /proc/meminfo.
+    #
+    # The function updates the associative array "memory_info".
+    #
+    # Requires: -
+
+    local line param value
+
+    while read line ; do
+        param="${line%%:*}"
+        value="${line##*:}"
+        value="${value// /}"  # remove spaces
+        [ "${value: -2}" == 'kB' ] && value=$(( ${value%%??} * 1024 )) # cut off unit and convert
+        memory_info["${param}"]="${value}"
+    done < /proc/meminfo 
+}
+
+function get_SAP_slice_data() {
+    # Params:   -
+    # Output:   -
+    # Exitcode: -
+    #
+    # Determines existence, state and memory information of the SAP slice.
+    #
+    # The function updates the associative array "SAP_slice_data".
+    #
+    # Requires: -
+
+    local path error
+
+    SAP_slice_data['name']='SAP.slice'
+
+    if systemctl cat "${SAP_slice_data['name']}" > /dev/null 2>&1 ; then
+        SAP_slice_data['exists']='yes'
+        SAP_slice_data['state_active']=$(systemctl is-active "${SAP_slice_data['name']}" 2> /dev/null)
+        SAP_slice_data['state_enabled']=$(systemctl is-enabled "${SAP_slice_data['name']}" 2> /dev/null)
+        SAP_slice_data['MemoryLow']=$(systemctl show -p MemoryLow --value "${SAP_slice_data['name']}" 2> /dev/null)
+        SAP_slice_data['memory.low']=$(cat "/sys/fs/cgroup/${SAP_slice_data['name']}/memory.low" 2>/dev/null)
+        SAP_slice_data['memory.low']=${SAP_slice_data['memory.low']:=0}
+        SAP_slice_data['memory.current']=$(cat "/sys/fs/cgroup/${SAP_slice_data['name']}/memory.current" 2>/dev/null)
+        SAP_slice_data['memory.current']=${SAP_slice_data['memory.current']:=0}
+
+        error=0
+        while read path ; do 
+            if [ -e "${path}/memory.low" ] ; then
+                ((error++))
+                continue
+            fi
+            if [ "$(< ${path}/memory.low)" != 'max' ] ; then
+                ((error++))
+                continue
+            fi 
+        done < <(find "/sys/fs/cgroup/${SAP_slice_data['name']}/" -mindepth 1 -type d)
+        if [ ${error} -ne 0 ] ; then 
+            SAP_slice_data['memory_low_children']='ok'
+        else
+            SAP_slice_data['memory_low_children']='false'
+        fi
+    else
+        SAP_slice_data['exists']='no'
+    fi
+}
+
+function get_SAP_process_data() {
+    # Params:   -
+    # Output:   -
+    # Exitcode: -
+    #
+    # Determines all processes of SAP instances and the ones outside SAP.slice.
+    #
+    # The function updates the associative arrays "SAP_instance_processes" and "SAP_processes_outside_cgroup" and "SAP_sapstartsrv_outside_cgroup"
+    # as well as the variables "SAP_processes" and "SAP_processes_outside".
+    #
+    # Requires: -
+
+    local pd line pid comm state ppid proc_ppid proc_comm sapstart_pids parent sapstart_list tmp_pid cmdline component profile_name instance cgroup sapstartsrv_proc no_sapstartsrv_proc 
+    declare -A proc_ppid proc_comm sapstart_pids 
+
+    # Collect current process information and create a list of sapstart/sapstartsrv processes.
+    for pd in /proc/[0-9]*/stat ; do 
+        [ -e "${pd}" ] || continue  # process has died meanwhile
+        read line  < "${pd}"
+
+        # Split line apart (comm can contain spaces, so the brackets have to be used as separator). 
+        pid="${line%% *}" ; line="${line#* }"
+        comm="${line%%)*}" ; comm="${comm:1}"; line="${line#*) }"
+        state="${line%% *}" ; line="${line#* }"
+        ppid="${line%% *}" ; line="${line#* }"
+        proc_ppid[${pid}]=${ppid} 
+        proc_comm[${pid}]="${comm}" 
+        [[ "${comm}" =~ ^sapstart(|srv)$ ]] && sapstart_pids[${pid}]="${pid}"
+    done
+
+    # Go through all pids and walk back through it's parents. and identify children of sapstart/sapstartsrv.
+    sapstart_list=" ${!sapstart_pids[@]} "  # all sapstart/sapstartsrv processes as string (leading and trailling spaces are important!) 
+    for pid in "${!proc_ppid[@]}" ; do
+        parent=${proc_ppid[${pid}]}
+        while [ ${parent} -gt 1 ] ; do
+            tmp_pid=${parent}
+            parent=${proc_ppid[${tmp_pid}]}
+            [[ "${sapstart_list}" =~ \ ${tmp_pid}\  ]] && sapstart_pids[${tmp_pid}]="${sapstart_pids[${tmp_pid}]} ${pid}"
+        done
+    done
+
+    # Aggregate proccesses per SAP instance.
+    for pid in "${!sapstart_pids[@]}" ; do 
+        [ -e "/proc/${pid}/cmdline" ] || continue
+        cmdline=$( tr '\0' ' ' < /proc/${pid}/cmdline)
+        for component in ${cmdline} ; do 
+            [ "${component:0:3}" == "pf=" ] && profile_name="${component##*/}" 
+        done
+        [ -z "${profile_name}" ] && continue   # profile is required
+        [ "${profile_name}" == 'host_profile' ] && continue  # HostAgent is not covered by WMP 
+
+        SAP_instance_processes[${profile_name}]="${SAP_instance_processes[${profile_name}]} ${sapstart_pids[${pid}]}"
+    done
+
+    # Collect all instance processes which are not in SAP.slice.
+    SAP_processes=0
+    for instance in "${!SAP_instance_processes[@]}" ; do
+        sapstartsrv_proc=0
+        no_sapstartsrv_proc=0
+	SAP_sapstartsrv_outside_cgroup[${instance}]=0
+        for pid in ${SAP_instance_processes[${instance}]} ; do
+	    ((SAP_processes++))
+            [ -e "/proc/${pid}/cgroup" ] || continue
+            if ! grep -q '^0::/SAP.slice/' "/proc/${pid}/cgroup" ; then 
+		SAP_processes_outside_cgroup[${instance}]="${SAP_processes_outside_cgroup[${instance}]} ${pid}"
+		((SAP_processes_outside++))
+		if [ "${proc_comm[${pid}]}" = "sapstartsrv" ] ; then 
+                    ((sapstartsrv_proc++))
+		else
+		    ((no_sapstartsrv_proc++)) 
+		fi
+
+	    fi
+        done
+        if [ ${sapstartsrv_proc} -gt 0 -a  ${no_sapstartsrv_proc} -eq 0 ] ; then
+	    SAP_sapstartsrv_outside_cgroup[${instance}]=1
+	fi 
+    done
+
+}
+
+function get_unit_states() {
+    # Params:   UNIT...
+    # Output:   -
+    # Exitcode: -
+    #
+    # Determines the state (is-active/is-enabled) for each UNIT.
+    # A missing state is reported as "missing".
+    #
+    # The function updates the associative arrays "unit_state_active" and "unit_state_enabled".
+    #
+    # Requires: -
+
+    local unit state_active state_enabled
+    for unit in "${@}" ; do
+        state_active=$(systemctl is-active "${unit}" 2> /dev/null)
+        state_enabled=$(systemctl is-enabled "${unit}" 2> /dev/null)
+        unit_state_active["${unit}"]=${state_active:-missing}
+        unit_state_enabled["${unit}"]=${state_enabled:-missing}
+    done
+}
+
+function get_swapaccounting_state() {
+    # Params:   -
+    # Output:   -
+    # Exitcode: -
+    #
+    # Determines if swapaccounting is configured and active.
+    #
+    # The function updates the associative array "swapaccounting_state".
+    #
+    # Requires: -
+
+    if [[ $(grep 'GRUB_CMDLINE_LINUX_DEFAULT' /etc/default/grub) =~ swapaccount=(1|true|yes) ]] ; then
+        swapaccounting_state['configured']='yes'
+    else
+        swapaccounting_state['configured']='no'
+    fi
+    if [ -e /sys/fs/cgroup/init.scope/memory.swap.current ] ; then
+        swapaccounting_state['active']='yes'
+    else
+        swapaccounting_state['active']='no'
+    fi
+}
+
+function check_pkg_version () {
+    # Params:   -
+    # Output:   -
+    # Exitcode: 2 if packages not installed properly
+    #
+    # Checks if required packages are installed correctly.
+    #
+    # Requires: -
+    local err_msg=""
+
+    for key in $(echo ${!required_pkgs[*]})
+    do
+        [[ -z ${package_version[$key]} ]] && err_msg=${err_msg}"Package '$key' not installed.\n" && continue
+
+        [[ -z ${required_pkgs[$key]} ]] && continue
+
+        if version_lt ${package_version[$key]} ${required_pkgs[$key]}; then
+            err_msg=${err_msg}"Package '$key(${package_version[$key]})' need upgrade to at least '$key(${required_pkgs[$key]})'.\n"
+        fi
+    done
+
+    if [ ! -z "$err_msg" ]; then
+        print_fail "$err_msg" "Please use zypper to install/upgrade."
+        exit 2
+    fi
+}
+
+function collect_data() {
+    # Params:   -
+    # Output:   -
+    # Exitcode: -
+    #
+    # Calls various functions to collect data.
+    #
+    # Requires: get_package_versions()
+    #           get_cgroup_state()
+    #           get_capture_state()
+    #           get_system_meminfo()
+    #           get_SAP_slice_data()
+    #           get_SAP_profile_data()
+    #           get_SAP_process_data()
+    #           get_unit_states()
+    #           get_swapaccounting_state()
+
+    # Collect data about some packages.
+    for pkg in $(echo ${!required_pkgs[*]})
+    do
+        get_package_versions $pkg
+    done
+
+    # Collect cgroup status.
+    get_cgroup_state
+
+    # Collect ownership and permissions of capture program.
+    get_capture_state
+
+    # Collect system memory information.
+    get_system_meminfo
+
+    # Collect data about SAP.slice.
+    get_SAP_slice_data
+
+    # Collect SAP instance profile data.
+    get_SAP_profile_data
+
+    # Collect SAP process information.
+    get_SAP_process_data
+
+    # Collect states of some systemd units.
+    get_unit_states wmp-sample-memory.timer
+
+    # Collect swap accounting status.
+    get_swapaccounting_state
+}
+
+
+function check_wmp() {
+    # Checks if WMP is installed correctly.
+    #
+    # - sap_wmp package should be installed
+    # - cgroups2 have to be active and enabled via GRUB 
+    # - cgroup v1 controllers should not be active
+    # - capture program has to have the correct ownership and permissions
+    # - Instance profile has been altered 
+    # - Instance processes are in SAP.slice
+    # - SAP.slice is configured and active (MemoryLow=/memory.low are set) 
+    # - MemoryLow should have a sane value
+    # - Timer unit to monitor cgroup data has been set.
+
+
+    local fails=0 warnings=0 tuned_used version_tag page_size
+
+    # We can stop, if required packages are not installed properly.
+    check_pkg_version
+
+    # Cgroup2 has to be configured and mounted in the unified hierarchy.
+    case "${cgroup_unified['active']}" in
+        yes)
+            case "${cgroup_unified['configured']}" in
+                yes)
+                    print_ok "cgroup2 unified hierarchy is mounted to /sys/fs/cgroup and configured in /etc/default/grub."
+                    ;;
+                needupdate)
+                    print_fail "cgroup2 unified hierarchy is mounted to /sys/fs/cgroup and configured in /etc/default/grub, but not updated." "Please run 'grub2-mkconfig -o /boot/grub2/grub.cfg' to update"
+                    ((fails++))
+                    ;;
+                no)
+                    print_fail "cgroup2 unified hierarchy is mounted to /sys/fs/cgroup, but not configured in /etc/default/grub." "Please rewrite the bootloader and reboot."
+                    ((fails++))
+                    ;;
+            esac  
+            ;;
+        no)
+            case "${cgroup_unified['configured']}" in 
+                yes)
+                    print_fail "cgroup2 unified hierarchy is configured in /etc/default/grub, but not active!" "Please rewrite the bootloader and reboot."    
+                    ;;
+                needupdate)
+                    print_fail "cgroup2 unified hierarchy is configured in /etc/default/grub, but not updated and active!" "Please rewrite the bootloader, run 'grub2-mkconfig -o /boot/grub2/grub.cfg' and reboot."
+                    ;;
+                no)
+                    print_fail "cgroup2 unified hierarchy is not configured!" "Please add 'systemd.unified_cgroup_hierarchy=true' to GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub, rewrite the bootloader and reboot."    
+                    ;;
+            esac
+            ((fails++))
+            ;;
+    esac
+
+
+    # No cgroup v1 controller should be active.
+    case "${cgroup_unified['v1-controllers']}" in 
+        no)
+            print_ok "No cgroup1 controllers mounted."
+            ;;
+        *memory*)
+            print_fail "The cgroup1 memory controller has been found, which is not supported with WMP!" "Please configure your system according to the documentation." 
+            ((fails++))
+            ;;    
+        *) 
+            print_warn "The following cgroup1 controllers have been found: ${cgroup_unified['v1-controllers']}. Verify that they do not interfere with WMP."
+            ;;
+    esac
+
+    # The capture program has to be have the permissions of 6750 and the ownership of root:sapsys
+    case "${capture_state['exists']}" in 
+        yes)
+            case "${capture_state['permissions']}:${capture_state['ownership']}" in 
+                6750:root:sapsys)
+                    print_ok "capture program has correct ownership and permissions."
+                    ;;
+                *)
+                    case "${capture_state['permissions']}" in 
+                        4750)   
+                            ;;
+                        *)
+                            print_fail "capture program has wrong permissions of ${capture_state['permissions']}!" "Reinstall the sapwmp package or change the permissions of ${capture_state['name']} to 6750."
+                            ((fails++))
+                            ;;
+                    esac
+                    case "${capture_state['ownership']}" in
+                        root:sapsys)
+                            ;;
+                        *)
+                            print_fail "capture program has wrong ownership of ${capture_state['ownership']}!" "Reinstall the sapwmp package or change the ownership of ${capture_state['name']} to root:sapsys. The SAP software has to be installed first!"
+                            ((fails++))
+                            ;;
+                    esac
+                    ;;
+            esac
+            ;;
+        no)
+            print_fail "capture program is missing!" "Reinstall the sapwmp package."
+            ((fails++))
+            ;;
+    esac    
+
+    # The instance profiles must call the capture program.
+    if [ ${#SAP_profile_path[@]} -eq 0 ] ; then
+        print_fail "Could not find any SAP instances!" "Check if SAP software has been installed correctly."
+        ((fails++))
+    else
+        counter=0
+        for instance in ${!SAP_profile_path[@]} ; do 
+            case "${SAP_profile_wmp_entry[${instance}]}" in 
+                -)
+                    print_note "No entry for the WMP capture program found in ${SAP_profile_path[${instance}]}."
+                    ;;
+                *)
+                    print_note "WMP entry for the WMP capture program found for instance ${instance}."
+                    ((counter++))
+                    ;;
+            esac 
+        done
+        case "${counter}" in 
+            0)
+                print_fail "All SAP instances miss the entry for the WMP capture program!" "Add the entry to the instance profile of the chosen instances."
+                ((fails++))
+                ;;
+            ${#SAP_profile_path[@]})
+                print_ok "All SAP instances contain the entry for the WMP capture program."
+                ;;
+            *)
+                print_warn "Only part of the SAP instances have been configured for WMP."
+                ((warnings++))
+                ;;
+        esac
+    fi
+
+    # The SAP slice must exists and be configured sanely.
+    case "${SAP_slice_data['exists']}" in
+        yes)
+            case "${SAP_slice_data['state_active']}" in  
+                active)
+                    print_ok "SAP slice is active."
+                    case "${SAP_slice_data['MemoryLow']}" in 
+                        0|18446744073709551615)
+                            print_fail "MemoryLow of ${SAP_slice_data['name']} is not set correctly to ${SAP_slice_data['MemoryLow']}!" "Please set MemoryLow to a correct value."
+                            ((fails++))
+                            ;;    
+                        *)
+                            page_size=$(getconf PAGE_SIZE)
+                            if [ $(( ${SAP_slice_data['MemoryLow']:-0} / ${page_size} )) -eq $(( ${SAP_slice_data['memory.low']:-0} / ${page_size} )) ] ; then
+                                print_ok "MemoryLow is set and in use."
+                            else
+                                print_fail "The cgroup ${SAP_slice_data['name']} has a different value for memory.low (${SAP_slice_data['memory.low']}) as configured for MemoryLow (${SAP_slice_data['MemoryLow']})" "Only the configuration file or the runtime value has been changed!"
+                                ((fails++))
+                            fi
+                            ;;
+                    esac
+                    ;;
+                inactive)
+                    print_fail "${SAP_slice_data['name']} is not active!" "Check if the SAP instances are started."
+                    ((fails++))
+                    ;;
+            esac
+            case "${SAP_slice_data['memory_low_children']}" in 
+                false)
+                    print_fail "Subcgroups of ${SAP_slice_data['name']} have either no MemoryLow setting or are not set to maximum!" "Check what has changed the parameters and restart the SAP instances."
+                    ((fails++))
+                    ;;
+            esac
+            ;;
+        no) 
+            print_fail "Unit file for ${SAP_slice_data['name']} is missing!" "Reinstall the sapwmp package."
+            ((fails++))
+            ;;
+    esac
+
+    # All instance processes must be in SAP.slice.
+    if [ ${SAP_processes} -eq 0 ] ; then
+        print_fail "No SAP instance processes found!" "Please start the SAP system."
+        ((fails++))
+    else
+        for instance in "${!SAP_instance_processes[@]}" ; do
+            case "${SAP_processes_outside_cgroup[${instance}]}" in 
+                '')
+                    print_ok "All processes of ${instance} are in SAP.slice."
+                    ;;
+                *)
+		    if [ ${SAP_sapstartsrv_outside_cgroup[${instance}]} -eq 1 ] ; then
+	    	        print_warn "Only sapstartsrv processes of ${instance} are outside SAP.slice!" "This is a special case and can be expected. Check documentation for details."
+			((warning++))
+		    else
+                        print_fail "Instance ${instance} has processes outside SAP.slice:${SAP_processes_outside_cgroup[${instance}]}."
+			((fails++))
+		    fi 	 
+                    ;;
+            esac
+        done
+     fi	
+
+
+    # Check if MemoryLow of the SAP slice is lower the memory.current and less then 3% as physical memory.
+    if [ -n "${SAP_slice_data['MemoryLow']}" ] ; then
+        if [ ${SAP_slice_data['MemoryLow']} -gt ${SAP_slice_data['memory.current']} ] ; then 
+            print_ok "MemoryLow is larger then the current allocated memory for ${SAP_slice_data['name']}."
+        else
+            print_fail "MemoryLow (${SAP_slice_data['MemoryLow']}) is smaller then the current allocated memory (${SAP_slice_data['memory.current']}) for ${SAP_slice_data['name']}!" "Check if this is an expected situation."
+            ((fails++))
+        fi
+        if [ ${SAP_slice_data['MemoryLow']} -lt ${memory_info['MemTotal']} ] ; then
+            print_ok "MemoryLow of ${SAP_slice_data['name']} is less then total memory."
+            memory_low_thresh=$(( ${memory_info['MemTotal']} * 97 / 100 ))
+            if [ ${SAP_slice_data['MemoryLow']} -gt ${memory_low_thresh} ] ; then
+                print_warn "MemoryLow of ${SAP_slice_data['name']} (${SAP_slice_data['MemoryLow']}) is very close to the total physical memory (${memory_info['MemTotal']})!"
+                ((warnings++))
+            fi
+        else
+            print_fail "MemoryLow of ${SAP_slice_data['name']} (${SAP_slice_data['MemoryLow']}) is not less then the total physical memory (${memory_info['MemTotal']})!" "Reduce MemoryLow."
+            ((fails++))
+        fi
+    else
+        print_fail "MemoryLow of ${SAP_slice_data['name']} is not configured!" "Configure MemoryLow."
+        ((fails++))
+    fi
+
+    # Check if the optional monitoring has been enabled.
+    case "${unit_state_active['wmp-sample-memory.timer']}" in 
+        active)
+                print_note "The timer unit wmp-sample-memory.timer to collect monitor data is active."
+                ;;
+        inactive)
+                print_note "The timer unit wmp-sample-memory.timer to collect monitor data is not active."
+                ;;
+    esac
+    case "${unit_state_enabled['wmp-sample-memory.timer']}" in 
+        enabled)
+                print_note "The optional timer unit wmp-sample-memory.timer to collect monitor data is enabled."
+                ;;
+        disabled)
+                print_note "The optional timer unit wmp-sample-memory.timer to collect monitor data is disabled."
+                ;;
+    esac
+
+    # Check if optional swap accounting is configured and enabled.
+    case "${swapaccounting_state['active']}" in
+        yes)
+            print_note "Optional swap accounting is active and can be monitored."
+            ;;
+        no)
+            print_note "Optional swap accounting is not active at the moment."
+            ;;
+    esac  
+    case "${swapaccounting_state['configured']}" in 
+        yes)
+            print_note "Optional swap accounting is configured in /etc/default/grub."    
+            ;;
+        no)
+            print_note "Optional swap accounting is not configured in /etc/default/grub."
+            ;;
+    esac
+
+    # Summary.
+    echo
+    [ ${warnings} -gt 0 ] && echo -e "${YELLOW}${warnings} warning(s)${RESET} have been found."
+    [ ${fails} -gt 0 ] && echo -e "${RED}${fails} error(s)${RESET} have been found."
+    if [ ${fails} -gt 0 ] ; then
+        echo "WMP will not work properly!"
+        return 1
+    else 
+        if [ ${warnings} -gt 0 ] ; then
+            echo "WMP should work properly, but better investigate!"
+        else
+            echo "WMP is set up correctly."
+        fi
+    fi
+    return 0    
+}
+
+
+# --- MAIN ---
+
+# Introduction.
+echo -e "\nThis is ${0##*/} v${version}."
+echo -e "It verifies if WMP is set up correctly.\n"
+echo -e "Please keep in mind:"
+echo -e " - It does not check if you have the latest version installed, only minimum version."
+echo -e " - It assumes SAP instances profiles can be found beneath /usr/sap/<SID>/SYS/profile/."
+echo -e " - This tool does not check, if the memory.low value is set correctly.\n"
+
+# Determine if we are running a SLES for SAP Applications 15.  #####  CHANGED TO RUN ON LEAP !! #######
+eval $(grep ^ID= /etc/os-release)
+eval $(grep ^VERSION= /etc/os-release)
+PROD=""
+
+[ -f "/etc/products.d/SLES_SAP.prod" ] && PROD="4sap"
+case "${ID}${PROD}-${VERSION-ID}" in
+    sles4sap-15|sles4sap-15-SP1|sles4sap-15-SP2)
+        ;;
+    sles4sap-15-SP3)
+        echo "Only SLES for SAP Applications 15 SP0/SP1/SP2 are supported yet! Support for ${VERSION} will follow soon. Exiting."
+        ;;
+    *)
+        echo "Only SLES for SAP Applications 15 SP0/SP1/SP2 are supported! Your OS is ${ID}${PROD}-${VERSION}. Exiting."
+        exit 2
+        ;;
+esac
+
+# Check parameters and act upon.
+case "${#}" in
+    0)  collect_data
+        check_wmp
+        exit $?
+        ;;
+    *)  echo "Usage: ${0##*/}"
+        exit 3
+        ;;
+esac
+
+# Bye.
+exit 0
+


### PR DESCRIPTION
This pull request including two enhancements:
1) Fix https://github.com/SUSE/sapwmp/issues/4
  Move the `wmp_check` script from [independent repo](https://github.com/scmschmidt/wmp_check/) to here to ease the checker management. Tested against SLE15SP0/SP1/SP2 already.
2) Remove the duplicated source in .spec file, install directly from the source code. Tested on SLE15SP2, installed rpm including files:
```
/etc/sapwmp.conf
/usr/lib/sapwmp
/usr/lib/sapwmp/sapwmp-capture
/usr/lib/sapwmp/scripts
/usr/lib/sapwmp/scripts/README-wmp-check.md
/usr/lib/sapwmp/scripts/wmp-check.sh
/usr/lib/sapwmp/wmp-sample-memory
/usr/lib/supportconfig
/usr/lib/supportconfig/plugins
/usr/lib/supportconfig/plugins/sapwmp
/usr/lib/systemd/system/SAP.slice
/usr/lib/systemd/system/wmp-sample-memory.service
/usr/lib/systemd/system/wmp-sample-memory.timer
```