### PR TITLE
Wmp checker remove sapstartsrv

### DIFF
--- a/rpm/sapwmp.conf
+++ b/rpm/sapwmp.conf
@@ -9,6 +9,6 @@ DEFAULT_SLICE="SAP.slice"
 ## Description: Comma-separated list of command names to which capture is
 ##              applied (matching against /proc/$PID/stat)
 ## Type:        string
-## Default:     sapstart,sapstartsrv
-PARENT_COMMANDS=sapstart,sapstartsrv
+## Default:     sapstart
+PARENT_COMMANDS=sapstart
 

--- a/rpm/supportconfig-sapwmp
+++ b/rpm/supportconfig-sapwmp
@@ -87,6 +87,7 @@ function display_swapped_procs() {
 
 # ---- Main ----
 echo "# Version: ${version}"
+display_cmd wmp-check
 display_cmd grep cgroup /proc/mounts
 display_file /proc/cmdline
 display_file /etc/default/grub

--- a/scripts/README-wmp-check.md
+++ b/scripts/README-wmp-check.md
@@ -163,3 +163,6 @@ WMP is set up correctly.
 |            |          | Check generated grub2 configure                       |
 |            |          | Enable support for SLE15SP0/SP1                       |
 |            |          | Support RPM package version check                     |
+| 19.04.2021 | v1.1.2   | Remove sapstartsrv from process tree to capture       |
+|            |          | Enable support for SLE15SP3                           |
+


### PR DESCRIPTION
bsc#1184865, sapstartsrv is removed from process tree.
Enable SLE15SP3
Call `wmp-check` in support config.

Compare to https://github.com/SUSE/sapwmp/pull/10 , only the last two commits are new created. I will do the rebase to ease the review  after https://github.com/SUSE/sapwmp/pull/10 merged.
(Didn't find a way to include this two commits only, since `wmp-check` only existed in https://github.com/SUSE/sapwmp/pull/10)